### PR TITLE
Fix to allow navigation for about:blank

### DIFF
--- a/src/config.xml.mustache
+++ b/src/config.xml.mustache
@@ -25,7 +25,7 @@
     <allow-navigation href="*://*.mendix.com/*" />
     <allow-navigation href="*://*.mendixcloud.com/*" />
     <allow-navigation href="*://*.mxapp.io/*" />
-    <allow-navigation href="about:blank" />
+    <allow-navigation href="about:*" />
 
     <!-- Force the default architecture for Android to ARM -->
     <plugin name="com.darktalker.cordova.screenshot" source="npm" spec="0.1.6" />


### PR DESCRIPTION
Running an app with a google maps iframe throws `ERROR Internal navigation rejected - <allow-navigation> not set for url='about:blank'` in the XCode console. This caused google maps embeds to only load partially on iOS. Using a wildcard in the rule fixes this and the error is no longer logged.