### PR TITLE
Fix click-to-call on Android

### DIFF
--- a/src/config.xml.mustache
+++ b/src/config.xml.mustache
@@ -16,7 +16,7 @@
     defaults.
     -->
     <preference name="phonegap-version" value="cli-8.1.1" />
-    <engine name="android" spec="7.1.3" />
+    <engine name="android" spec="7.1.4" />
     <engine name="ios" spec="4.5.5" />
 
     <!-- allow assets to be loaded and open links in the app itself, see: http://phonegap.com/blog/2012/03/20/access-tags/ -->


### PR DESCRIPTION
Click to call, text or email do not work on Android when usng the 7.1.3 engine.