### PR TITLE
Expose scripts for npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lib": "src"
   },
   "files": [
+    "/scripts/*.js",
     "/config",
     "/src",
     "/*.json",


### PR DESCRIPTION
Fixes `npm i @mendix/mendix-hybrid-app-base` wouldn't install `scripts/before_build.js` since its not exposed
