### PR TITLE
cordova-sqlite-storage is updated to version 6.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mendix/mendix-hybrid-app-base",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mendix/mendix-hybrid-app-base",
-      "version": "6.0.2",
+      "version": "6.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/mendix-hybrid-app-base",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "Mendix PhoneGap Build base package",
   "scripts": {
     "appbase": "node ./node_modules/webpack/bin/webpack --config ./webpack.config.appbase.js",

--- a/src/config.xml.mustache
+++ b/src/config.xml.mustache
@@ -42,7 +42,7 @@
     <plugin name="cordova-plugin-vibration" source="npm" spec="3.1.0" />
     <plugin name="cordova-plugin-x-socialsharing" source="npm" version="5.6.4"/>
     <plugin name="cordova-plugin-zip" source="npm" spec="3.1.0" />
-    <plugin name="@mendix/cordova-sqlite-storage" source="npm" spec="2.0.4-mx.1.1.0" />
+    <plugin name="cordova-sqlite-storage" source="npm" spec="6.1.0" />
     <plugin name="@mendix/uk.co.workingedge.phonegap.plugin.launchnavigator" source="npm" spec="4.2.2-mx.1.0.0" />
 
     {{#permissions.calendar}}


### PR DESCRIPTION
[cordova-sqlite-storage](https://github.com/storesafe/cordova-sqlite-storage/blob/dev/CHANGES.md) is updated to version 6.1.0.