### PR TITLE
[MOO-1376] Change scheme value to 'app' and make available for only iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This project can be used to create a templated Phonegap Build package, as used w
     - Linux, BSD, etc: install using the available package manager, e.g. on Debian: `sudo apt-get install node`
 - To customize the runtime behavior, include the following configuration: Set [com.mendix.core.SameSiteCookies](https://docs.mendix.com/refguide/custom-settings/#commendixcoreSameSiteCookies) to `None` in Studio Pro.
 - Deploy and test the application using HTTPS.
+- The scheme configuration in `config.xml` should not be changed to any value other than `app` for iOS.
 
 ### Build
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mendix/mendix-hybrid-app-base",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mendix/mendix-hybrid-app-base",
-      "version": "8.0.0",
+      "version": "8.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/mendix-hybrid-app-base",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Mendix PhoneGap Build base package",
   "scripts": {
     "appbase": "node ./node_modules/webpack/bin/webpack --config ./webpack.config.appbase.js",

--- a/src/config.xml.mustache
+++ b/src/config.xml.mustache
@@ -117,10 +117,11 @@
         <plugin name="@ahovakimyan/cordova-plugin-wkwebviewxhrfix" source="npm" spec="1.0.2" />
 
         <preference name="KeyboardDisplayRequiresUserAction" value="false" />
-        <preference name="scheme" value="https" />
-        <preference name="hostname" value="localhost" />
 
         <platform name="ios">
+            <preference name="scheme" value="app" />
+            <preference name="hostname" value="localhost" />
+
             {{#iosImages}}
                 <{{{tag}}} src="{{{filename}}}" width="{{{width}}}" height="{{{height}}}" />
             {{/iosImages}}


### PR DESCRIPTION
- Scheme value changed to a non-reserved keyword. Reserved keywords are listed in the [cordova documentation](https://cordova.apache.org/docs/en/12.x/config_ref/).
- The new scheme value is only available for iOS.