### PR TITLE
Updated cordova-sqlite-storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mendix/mendix-hybrid-app-base",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mendix/mendix-hybrid-app-base",
-      "version": "9.0.3",
+      "version": "9.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/mendix-hybrid-app-base",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "description": "Mendix PhoneGap Build base package",
   "scripts": {
     "appbase": "node ./node_modules/webpack/bin/webpack --config ./webpack.config.appbase.js",

--- a/src/config.xml.mustache
+++ b/src/config.xml.mustache
@@ -42,7 +42,7 @@
     <plugin name="cordova-plugin-vibration" source="npm" spec="3.1.0" />
     <plugin name="cordova-plugin-x-socialsharing" source="npm" version="6.0.4"/>
     <plugin name="cordova-plugin-zip" source="npm" spec="3.1.0" />
-    <plugin name="cordova-sqlite-storage" source="npm" spec="6.1.0" />
+    <plugin name="cordova-sqlite-storage" source="npm" spec="7.0.0" />
     <plugin name="@mendix/uk.co.workingedge.phonegap.plugin.launchnavigator" source="npm" spec="4.2.2-mx.1.0.0" />
 
     {{#permissions.calendar}}


### PR DESCRIPTION
Updated cordova-sqlite to be compatible with Google Play’s 16 KB page size requirement